### PR TITLE
Handling multiple domains for the same plugin

### DIFF
--- a/chrome-extension/js/background.js
+++ b/chrome-extension/js/background.js
@@ -66,6 +66,11 @@ function extractRootDomain(url) {
       domain = splitArr[arrLen - 3] + '.' + domain;
     }
   }
+
+  if (domain.startsWith('www.')) {
+    domain = domain.substring(4);
+  }
+
   return domain;
 }
 
@@ -178,18 +183,17 @@ chrome.commands.onCommand.addListener((command) => {
 
 chrome.webNavigation.onCompleted.addListener((details) => {
   let domain = extractRootDomain(details.url);
-  let filename = domain.split('.')[0]; // TODO: Need cleaner way to do this
-  console.log('google.com' in Plugins, Plugins);
-  // TODO: This doesn't work for suburls or non .com urls
-  if (!(filename + '.com' in Plugins)) {
-    return;
-  }
-
-  chrome.tabs.executeScript({ file: filename + '.js' }, () => {
-    chrome.tabs.insertCSS(details.tabId, { file: filename + '.css' }, function() {
-    });
-    chrome.tabs.sendMessage(details.tabId, { loadShortcuts: true });
-  });
+  getPlugin(domain,
+    // success: initialize plugin scripts
+    (plugin) => {
+      let pluginName = plugin.default.pluginName
+      chrome.tabs.executeScript({ file: pluginName + '.js' }, () => {
+        chrome.tabs.insertCSS(details.tabId, { file: pluginName + '.css' }, () => {});
+        chrome.tabs.sendMessage(details.tabId, { loadShortcuts: true });
+      });
+    },
+    // fail: no plugins found, do nothing
+    () => {});
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/chrome-extension/plugin/google.ts
+++ b/chrome-extension/plugin/google.ts
@@ -77,7 +77,11 @@ let shortcuts = {
 
 let pb = new PluginBuilder();
 
-pb.setDomainName('google.com');
+pb.setPluginName('google');
+
+pb.addDomainName('google.com');
+pb.addDomainName('google.ca');
+
 pb.setInitialState({
   linkIndex: 0
 });

--- a/chrome-extension/plugin/messenger.ts
+++ b/chrome-extension/plugin/messenger.ts
@@ -86,7 +86,8 @@ let shortcuts = {
 ///////////////////////////////////////
 let pb = new PluginBuilder();
 
-pb.setDomainName('messenger.com');
+pb.setPluginName('messenger');
+pb.addDomainName('messenger.com');
 pb.setInitialState({});
 
 pb.registerShortcut('Next chat', shortcuts.nextRow, (event, state) => {

--- a/chrome-extension/plugin/plugins.ts
+++ b/chrome-extension/plugin/plugins.ts
@@ -1,7 +1,6 @@
 import * as Google from './google.ts';
 import * as Messenger from './messenger.ts';
 import * as Youtube from './youtube.ts';
-import { Plugin } from './pluginbuilder.ts';
 
 let plugins = [Google, Messenger, Youtube];
 let domainToPlugin = {};

--- a/chrome-extension/plugin/plugins.ts
+++ b/chrome-extension/plugin/plugins.ts
@@ -1,9 +1,27 @@
 import * as Google from './google.ts';
 import * as Messenger from './messenger.ts';
 import * as Youtube from './youtube.ts';
+import { Plugin } from './pluginbuilder.ts';
 
-export default {
-  'google.com': Google,
-  'messenger.com': Messenger,
-  'youtube.com': Youtube
-};
+let plugins = [Google, Messenger, Youtube];
+let domainToPlugin = {};
+// @ts-ignore
+let pluginNameSet = new Set([]);
+
+// Build map of domain to plugin while validating unique domain and plugin names
+for (let plugin of plugins) {
+  let pluginName = plugin.default.pluginName
+  if (pluginNameSet.has(pluginName)) {
+    throw 'Plugin with this name already exists: ' + pluginName;
+  }
+  pluginNameSet.add(pluginName);
+
+  for (let domain of plugin.default.domains) {
+    if (domainToPlugin.hasOwnProperty(domain)) {
+      throw 'This domain has already been defined: ' + domain;
+    }
+    domainToPlugin[domain] = plugin;
+  }
+}
+
+export default domainToPlugin;

--- a/chrome-extension/plugin/youtube.ts
+++ b/chrome-extension/plugin/youtube.ts
@@ -38,7 +38,8 @@ let shortcuts = {
 ///////////////////////////////////////
 let pb = new PluginBuilder();
 
-pb.setDomainName('youtube.com');
+pb.setPluginName('youtube');
+pb.addDomainName('youtube.com');
 pb.setInitialState({
   higlightedIndex: -1
 });


### PR DESCRIPTION
- i.e. `google.ca` and `google.com` they're mapped to the same plugin. 
- Allows subdomains or similar domains to map to different plugins by now specifying a unique plugin name when creating a plugin.
- Dynamically generate plugin meta data
- Clean up code