### PR TITLE
Hide messenger shortcuts

### DIFF
--- a/chrome-extension/plugin/messenger.ts
+++ b/chrome-extension/plugin/messenger.ts
@@ -7,7 +7,7 @@ let shortcuts = {
   previousUnreadRow: ['option+shift+k', 'option+shift+up'],
   sendEmoji: 'command+enter',
   toggleInfo: 'option+\\',
-  searchMessenger: 'option+\/',
+  searchMessenger: 'option+s',
   messageInput: 'escape',
   composeMessage: 'option+c',
   searchConversation: 'option+f',
@@ -232,14 +232,12 @@ function viewChat(i, event, state) {
 pb.registerShortcut('View first chat', shortcuts.firstChat, viewChat.bind(this, 0));
 pb.registerShortcut('View second chat', shortcuts.secondChat, viewChat.bind(this, 1));
 pb.registerShortcut('View third chat', shortcuts.thirdChat, viewChat.bind(this, 2));
-pb.registerShortcut('View fourth chat', shortcuts.fourthChat, viewChat.bind(this, 3));
-pb.registerShortcut('View fifth chat', shortcuts.fifthChat, viewChat.bind(this, 4));
-pb.registerShortcut('View sixth chat', shortcuts.sixthChat, viewChat.bind(this, 5));
-pb.registerShortcut('View seventh chat', shortcuts.seventhChat, viewChat.bind(this, 6));
-pb.registerShortcut('View eighth chat', shortcuts.eighthChat, viewChat.bind(this, 7));
-pb.registerShortcut('View ninth chat', shortcuts.ninthChat, viewChat.bind(this, 8));
-
-
+pb.registerShortcut('View fourth chat', shortcuts.fourthChat, viewChat.bind(this, 3), { showInPanel: false });
+pb.registerShortcut('View fifth chat', shortcuts.fifthChat, viewChat.bind(this, 4), { showInPanel: false });
+pb.registerShortcut('View sixth chat', shortcuts.sixthChat, viewChat.bind(this, 5), { showInPanel: false });
+pb.registerShortcut('View seventh chat', shortcuts.seventhChat, viewChat.bind(this, 6), { showInPanel: false });
+pb.registerShortcut('View eighth chat', shortcuts.eighthChat, viewChat.bind(this, 7), { showInPanel: false });
+pb.registerShortcut('View ninth chat', shortcuts.ninthChat, viewChat.bind(this, 8), { showInPanel: false });
 
 let plugin = pb.build();
 export default plugin;

--- a/chrome-extension/plugin/pluginbuilder.ts
+++ b/chrome-extension/plugin/pluginbuilder.ts
@@ -58,29 +58,16 @@ export class Plugin {
   // MDS getter for frontend
   // returns a list of shortcut objects in MDS
   getShortcutsMDS() : object[] {
-    return this.shortcuts.map(s => {
-      let MDS = s.keys.map(key => { return {default: [key]}; });
-      return {
-        name: s.name,
-        keys: MDS,
-        action: s.action
-      };
+    return this.shortcuts.filter((s) => {
+      return s.showInPanel;
+    }).map((s) => {
+      // clone shortcut to not affect the underlying data
+      let shortcut = JSON.parse(JSON.stringify(s));
+      delete shortcut.showInPanel;
+      shortcut.keys = s.keys.map(key => { return {default: [key]}; });
+      return shortcut;
     });
   }
-
-  listShortcuts() : any[] {
-    // Only include name and keys
-    return this.shortcuts.map((s) => {
-      return {
-        name: s.name,
-        keys: s.keys
-      };
-    });
-  }
-
-  // getShortcut(name: string) : any {
-  //   return this.shortcuts[name];
-  // }
 }
 
 // Provides an API for third party developers to create customs plugins for a url that matches our regex
@@ -100,7 +87,8 @@ export class PluginBuilder {
   // TODO: Handle scopes from keymaster
   registerShortcut(name: string,
                    keys: string | string[],
-                   action: Function) : void {
+                   action: Function,
+                   options?: any) : void {
     if (!name) {
       throw 'Must include a name.';
     }
@@ -111,7 +99,12 @@ export class PluginBuilder {
 
     let config = {
       keys: keys,
-      action: action
+      action: action,
+      showInPanel: true
+    }
+
+    if (options && !options.showInPanel) {
+      config.showInPanel = false;
     }
 
     this.validateConfig(config);
@@ -127,10 +120,6 @@ export class PluginBuilder {
   }
 
   validateConfig(config: any) : boolean {
-    // Structure: {
-    //   'keys': string[],
-    //   'action': <function Function>
-    // }
 
     // Validate keys
     if (config.keys.constructor !== Array) {
@@ -167,7 +156,8 @@ export class PluginBuilder {
       shortcuts.push({
         name: name,
         keys: this.shortcuts[name].keys,
-        action: this.shortcuts[name].action
+        action: this.shortcuts[name].action,
+        showInPanel: this.shortcuts[name].showInPanel
       });
     }
 


### PR DESCRIPTION
- Change search key to `alt+s` for messenger
- Added generic way to hide shortcuts but still have them active
- Cleaned up some unused code